### PR TITLE
Allow infinite triggering

### DIFF
--- a/scheduler/serializers.py
+++ b/scheduler/serializers.py
@@ -29,8 +29,8 @@ class ScheduleSerializer(serializers.HyperlinkedModelSerializer):
                             'celery_interval_definition')
         fields = ('url', 'id', 'frequency', 'cron_definition',
                   'interval_definition', 'endpoint', 'payload', 'auth_token',
-                  'next_send_at', 'created_at', 'created_by', 'updated_at',
-                  'updated_by')
+                  'next_send_at', 'enabled', 'created_at', 'created_by',
+                  'updated_at', 'updated_by')
 
 
 class HookSerializer(serializers.ModelSerializer):

--- a/scheduler/tasks.py
+++ b/scheduler/tasks.py
@@ -94,7 +94,7 @@ class QueueTasks(Task):
         l.info("Filtered schedule count: <%s>" % schedules.count())
         queued = 0
         for schedule in schedules:
-            if schedule.triggered < schedule.frequency:
+            if schedule.frequency is not None and schedule.triggered < schedule.frequency:
                 schedule.triggered += 1
                 if schedule.triggered == schedule.frequency:
                     # schedule must have hit it's limit

--- a/scheduler/tasks.py
+++ b/scheduler/tasks.py
@@ -94,7 +94,14 @@ class QueueTasks(Task):
         l.info("Filtered schedule count: <%s>" % schedules.count())
         queued = 0
         for schedule in schedules:
-            if schedule.frequency is not None and schedule.triggered < schedule.frequency:
+            if schedule.frequency is None:
+                schedule.triggered += 1
+                schedule.save()
+                DeliverTask.apply_async(kwargs={
+                    "schedule_id": str(schedule.id)})
+                queued += 1
+
+            elif schedule.triggered < schedule.frequency:
                 schedule.triggered += 1
                 if schedule.triggered == schedule.frequency:
                     # schedule must have hit it's limit

--- a/scheduler/tests.py
+++ b/scheduler/tests.py
@@ -229,6 +229,31 @@ class TestSchedudlerAppAPI(AuthenticatedAPITestCase):
                 ]
             })
 
+    def test_update_schedule(self):
+        # Setup
+        s = self.make_schedule()
+        post_data = {
+            "enabled": False
+        }
+        # Precheck
+        self.assertEqual(s.enabled, True)
+        self.assertEqual(s.frequency, 2)
+        self.assertEqual(s.cron_definition, "25 * * * *")
+        self.assertEqual(s.interval_definition, None)
+        self.assertEqual(s.endpoint, "http://example.com")
+        # Execute
+        response = self.client.patch('/api/v1/schedule/%s/' % s.id,
+                                     json.dumps(post_data),
+                                     content_type='application/json')
+        s.refresh_from_db()
+        # Check
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(s.enabled, False)
+        self.assertEqual(s.frequency, 2)
+        self.assertEqual(s.cron_definition, "25 * * * *")
+        self.assertEqual(s.interval_definition, None)
+        self.assertEqual(s.endpoint, "http://example.com")
+
     def test_create_webhook(self):
         # Setup
         user = User.objects.get(username='testuser')


### PR DESCRIPTION
The model allows `frequency` to be set to `None`.  Change the `QueueTasks` task to also run the `DeliverTask` task if `frequency` is `None`.

Currently thinking to change this line:
`if schedule.triggered < schedule.frequency:`
to:
`if schedule.frequency is None or schedule.triggered < schedule.frequency:`

This issue links with https://github.com/praekelt/seed-stage-based-messaging/issues/31
