### PR TITLE
Use an iterator instead of caching the result set

### DIFF
--- a/scheduler/tasks.py
+++ b/scheduler/tasks.py
@@ -93,7 +93,7 @@ class QueueTasks(Task):
         # create tasks for each active schedule
         l.info("Filtered schedule count: <%s>" % schedules.count())
         queued = 0
-        for schedule in schedules:
+        for schedule in schedules.iterator():
             if schedule.frequency is None:
                 schedule.triggered += 1
                 schedule.save()


### PR DESCRIPTION
Looping over the standard queryset works fine under most circumestances,
the problem is that it caches the result set which when you're running 
under constrained memory circumstances can be a problem.