### PR TITLE
Change to seed metrics client

### DIFF
--- a/scheduler/tasks.py
+++ b/scheduler/tasks.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.db import connection, transaction
 from django.utils.timezone import now
 from djcelery.models import CrontabSchedule, IntervalSchedule
-from go_http.metrics import MetricsApiClient
+from seed_services_client.metrics import MetricsApiClient
 from requests import exceptions as requests_exceptions
 
 from seed_scheduler import utils
@@ -206,8 +206,8 @@ queue_tasks = QueueTasks()
 
 def get_metric_client(session=None):
     return MetricsApiClient(
-        auth_token=settings.METRICS_AUTH_TOKEN,
-        api_url=settings.METRICS_URL,
+        url=settings.METRICS_URL,
+        auth=settings.METRICS_AUTH,
         session=session)
 
 
@@ -223,7 +223,7 @@ class FireMetric(Task):
             metric_name: metric_value
         }
         metric_client = get_metric_client(session=session)
-        metric_client.fire(metric)
+        metric_client.fire_metrics(**metric)
         return "Fired metric <%s> with value <%s>" % (
             metric_name, metric_value)
 

--- a/seed_scheduler/settings.py
+++ b/seed_scheduler/settings.py
@@ -223,7 +223,10 @@ CELERYD_MAX_TASKS_PER_CHILD = 50
 djcelery.setup_loader()
 
 METRICS_URL = os.environ.get("METRICS_URL", None)
-METRICS_AUTH_TOKEN = os.environ.get("METRICS_AUTH_TOKEN", "REPLACEME")
+METRICS_AUTH = (
+    os.environ.get("METRICS_AUTH_USER", "REPLACEME"),
+    os.environ.get("METRICS_AUTH_PASSWORD", "REPLACEME"),
+)
 
 DEFAULT_REQUEST_TIMEOUT = float(os.environ.get("DEFAULT_REQUEST_TIMEOUT", 30))
 DEFAULT_CLOCK_SKEW_SECONDS = int(

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'pytz==2015.7',
         'django-rest-hooks==1.3.1',
         'crontab==0.20.5',
-        'go_http==0.3.0',
+        'seed-services-client==0.21.0',
         'drfdocs==0.0.11',
     ],
     classifiers=[


### PR DESCRIPTION
Currently, we are using the vumi go metrics client. In order to be able to use authentication with our metrics, we need to switch to the seed metrics client