### PR TITLE
Upgrade django-celery package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'django-filter==1.0.2',
         'whitenoise==2.0.6',
         'celery==3.1.24',
-        'django-celery==3.1.17',
+        'django-celery==3.2.2',
         'redis==2.10.5',
         'pytz==2015.7',
         'django-rest-hooks==1.3.1',


### PR DESCRIPTION
The `django` version was upgraded from 1.9 to 1.11 recently and the current `django-celery` version is not compatible with `django >=1.10`. 

This updates `django-celery` to `3.2.2` where the compatibility issues are sorted.

https://github.com/celery/django-celery/blob/master/Changelog