### PR TITLE
Add prometheus metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+.pytest_cache
 
 # Translations
 *.mo

--- a/scheduler/models.py
+++ b/scheduler/models.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.contrib.postgres.fields import JSONField
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models.signals import post_save, pre_save
+from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
@@ -171,16 +171,6 @@ def schedule_saved(sender, instance, **kwargs):
                 "args": '["interval", %s]' % intsch.id,
             }
             PeriodicTask.objects.create(**pt)
-
-
-@receiver(post_save, sender=Schedule)
-def fire_metrics_if_new(sender, instance, created, **kwargs):
-    from .tasks import fire_metric
-
-    if created:
-        fire_metric.apply_async(
-            kwargs={"metric_name": "schedules.created.sum", "metric_value": 1.0}
-        )
 
 
 @python_2_unicode_compatible

--- a/scheduler/tests.py
+++ b/scheduler/tests.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 import responses
 from django.contrib.auth.models import Group, User
 from django.core.management import call_command
-from django.db.models.signals import post_save
 from django.test import TestCase, override_settings
 from django.utils import timezone
 from django.utils.six import StringIO
@@ -19,7 +18,7 @@ from rest_hooks.models import Hook
 
 from seed_scheduler import celery_app
 
-from .models import QueueTaskRun, Schedule, ScheduleFailure, fire_metrics_if_new
+from .models import QueueTaskRun, Schedule, ScheduleFailure
 from .tasks import deliver_task, fire_metric, queue_tasks, requeue_failed_tasks
 
 try:
@@ -59,15 +58,8 @@ class AuthenticatedAPITestCase(APITestCase):
         }
         return Schedule.objects.create(**schedule_data)
 
-    def _replace_post_save_hooks(self):
-        post_save.disconnect(fire_metrics_if_new, sender=Schedule)
-
-    def _restore_post_save_hooks(self):
-        post_save.connect(fire_metrics_if_new, sender=Schedule)
-
     def setUp(self):
         super(AuthenticatedAPITestCase, self).setUp()
-        self._replace_post_save_hooks()
 
         self.username = "testuser"
         self.password = "testpass"
@@ -82,9 +74,6 @@ class AuthenticatedAPITestCase(APITestCase):
         )
         sutoken = Token.objects.create(user=self.superuser)
         self.adminclient.credentials(HTTP_AUTHORIZATION="Token %s" % sutoken)
-
-    def tearDown(self):
-        self._restore_post_save_hooks()
 
 
 class TestSchedulerAppAPI(AuthenticatedAPITestCase):
@@ -897,23 +886,6 @@ class TestMetrics(AuthenticatedAPITestCase):
         self.check_request(responses.calls[0].request, "POST", data={"foo.last": 1.0})
         self.assertEqual(result.get(), "Fired metric <foo.last> with value <1.0>")
 
-    @responses.activate
-    def test_created_metrics(self):
-        # Setup
-        self.add_metrics_response()
-        # reconnect metric post_save hook
-        post_save.connect(fire_metrics_if_new, sender=Schedule)
-
-        # Execute
-        self.make_schedule()
-
-        # Check
-        self.check_request(
-            responses.calls[0].request, "POST", data={"schedules.created.sum": 1.0}
-        )
-        # remove post_save hooks to prevent teardown errors
-        post_save.disconnect(fire_metrics_if_new, sender=Schedule)
-
 
 class TestUserCreation(AuthenticatedAPITestCase):
     def test_create_user_and_token(self):
@@ -1040,7 +1012,6 @@ class TestTriggerDeliverTasks(TestCase):
     timeout = 1
 
     def setUp(self):
-        post_save.disconnect(fire_metrics_if_new, sender=Schedule)
         self.session = TestSession()
         self.crontab_schedule = CrontabSchedule.objects.create(
             **{

--- a/seed_scheduler/decorators.py
+++ b/seed_scheduler/decorators.py
@@ -1,0 +1,21 @@
+import functools
+
+from django.core.exceptions import PermissionDenied
+
+
+def internal_only(view_func):
+    """
+    A view decorator which blocks access for requests coming through the load balancer.
+    """
+
+    @functools.wraps(view_func)
+    def wrapper(request, *args, **kwargs):
+        forwards = request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")
+        # The nginx in the docker container adds the loadbalancer IP to the list inside
+        # X-Forwarded-For, so if the list contains more than a single item, we know
+        # that it went through our loadbalancer
+        if len(forwards) > 1:
+            raise PermissionDenied()
+        return view_func(request, *args, **kwargs)
+
+    return wrapper

--- a/seed_scheduler/settings.py
+++ b/seed_scheduler/settings.py
@@ -52,17 +52,20 @@ INSTALLED_APPS = (
     "django_filters",
     "rest_hooks",
     "djcelery",
+    "django_prometheus",
     # us
     "scheduler",
 )
 
 MIDDLEWARE = (
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 )
 
 ROOT_URLCONF = "seed_scheduler.urls"
@@ -77,7 +80,8 @@ DATABASES = {
     "default": dj_database_url.config(
         default=os.environ.get(
             "SCHEDULER_DATABASE", "postgres://postgres:@localhost/seed_scheduler"
-        )
+        ),
+        engine="django_prometheus.db.backends.postgresql",
     )
 }
 

--- a/seed_scheduler/test_decorators.py
+++ b/seed_scheduler/test_decorators.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+
+
+class InternalOnlyTests(TestCase):
+    def test_internal_access(self):
+        """
+        Internal access should be allowed
+        """
+        url = reverse("metrics")
+        response = self.client.get(url, HTTP_X_FORWARDED_FOR="1.2.3.4")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_external_access(self):
+        """
+        External access through the load balancer should be blocked
+        """
+        url = reverse("metrics")
+        response = self.client.get(url, HTTP_X_FORWARDED_FOR="1.2.3.4, 4.3.2.1")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/seed_scheduler/urls.py
+++ b/seed_scheduler/urls.py
@@ -8,6 +8,7 @@ from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework.documentation import include_docs_urls
 
 from scheduler import views
+from seed_scheduler.decorators import internal_only
 
 admin.site.site_header = os.environ.get("SCHEDULER_TITLE", "Scheduler Admin")
 
@@ -20,5 +21,7 @@ urlpatterns = [
     url(r"^api/health/", views.HealthcheckView.as_view()),
     url(r"^", include("scheduler.urls")),
     path("docs/", include_docs_urls(title=admin.site.site_header)),
-    path("metrics", django_prometheus.ExportToDjangoView, name="metrics")
+    path(
+        "metrics", internal_only(django_prometheus.ExportToDjangoView), name="metrics"
+    ),
 ]

--- a/seed_scheduler/urls.py
+++ b/seed_scheduler/urls.py
@@ -3,6 +3,7 @@ import os
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.urls import path
+from django_prometheus import exports as django_prometheus
 from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework.documentation import include_docs_urls
 
@@ -19,4 +20,5 @@ urlpatterns = [
     url(r"^api/health/", views.HealthcheckView.as_view()),
     url(r"^", include("scheduler.urls")),
     path("docs/", include_docs_urls(title=admin.site.site_header)),
+    path("metrics", django_prometheus.ExportToDjangoView, name="metrics")
 ]

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "django-rest-hooks==1.5.0",
         "crontab==0.22.4",
         "seed-services-client==0.37.0",
+        "django_prometheus==1.0.15",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This PR adds basic django prometheus metrics, and exports them via an internal only endpoint.